### PR TITLE
[feat]协程池事件状态任务处理与协程oom问题重构

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,4 @@ COPY --chown=repair-robt:repair-robt . .
 
 EXPOSE 8080
 
-CMD ["gunicorn", "app.main:app", \
-     "--timeout", "0", \
-     "--bind", "0.0.0.0:8080", \
-     "--workers", "4", \
-     "--worker-class", "uvicorn.workers.UvicornWorker", \
-     "--worker-tmp-dir", "/dev/shm", \
-     "--preload"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 import os
 
 import yaml
-
+from mysql.connector import pooling
 
 class Settings:
     def __init__(self):
@@ -36,7 +36,30 @@ class Settings:
             self.fix_success_comment: str = config.get("FIX_SUCCESS_COMMENT")
             self.fix_failure_comment: str = config.get("FIX_FAILURE_COMMENT")
             self.fix_error_comment: str = config.get("FIX_ERROR_COMMENT")
+            self.thread_pool_size: int = config.get("THREAD_POOL_SIZE")
+            self.check_interval: int = config.get("CHECK_INTERVAL")
+            self.host: str = config.get("HOST")
+            self.port: str = config.get("PORT")
+            self.user: str = config.get("USER")
+            self.password: str = config.get("PASSWORD")
+            self.database: str = config.get("DATABASE")
+            self.pool_size: int = config.get("POOL_SIZE")
         #os.remove(config_path_env)
 
 
 settings = Settings()
+
+db_config = {
+    "user": settings.user,
+    "password": settings.password,
+    "host": settings.host,
+    "port": settings.port,
+    "database": settings.database,
+    'charset': 'utf8mb4'
+}
+def init_db_pool():
+    return pooling.MySQLConnectionPool(
+        pool_name="request_pool",
+        pool_size=settings.pool_size,
+        **db_config
+    ) 

--- a/app/utils/processor.py
+++ b/app/utils/processor.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python3
+# ******************************************************************************
+# Copyright (c) openEuler. 2025. All rights reserved.
+# licensed under the Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#     http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN 'AS IS' BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR
+# PURPOSE.
+# See the Mulan PSL v2 for more details.
+# ******************************************************************************/
+
+import time
+from app.config import settings, init_db_pool
+from app.api.endpoints.webhook import process_initial_repair
+import logging
+import asyncio
+
+
+REPAIR_STATUS_COMPLETED = "completed"
+REPAIR_STATUS_FAILED = "failed"
+REPAIR_STATUS_PROCESSING = "processing"
+REPAIR_STATUS_PENDING = "pending"
+
+logger = logging.getLogger(__name__)
+class RequestProcessor:
+    def __init__(self):
+        """
+        初始化数据库连接池和线程池。
+        """
+        self.db_pool = init_db_pool()
+        self.check_interval = settings.check_interval
+        self.task_queue = asyncio.Queue()
+        for _ in range(settings.thread_pool_size):
+            asyncio.create_task(self.worker())
+
+    async def worker(self):
+        """工作者协程持续处理队列中的任务
+    
+        该协程不断从任务队列中获取请求数据，并尝试处理这些请求。
+        如果处理过程中发生错误，确保任务被标记为已完成，以维护队列的正确性。
+        """
+        while True:
+            request_data = await self.task_queue.get()
+            try:
+                await self.process_request(request_data[0], request_data[1])
+            finally:
+                self.task_queue.task_done()
+
+    async def start(self):
+        """
+        启动后台任务。
+        """
+        while True:
+            await self.process_pending_requests()
+            await asyncio.sleep(self.check_interval)
+    
+    async def process_pending_requests(self):
+        """
+        处理挂起的请求。该方法从数据库中获取状态为'pending'或'failed'的请求，
+        将其标记为'processing'，并提交到线程池中异步处理。
+        """
+        try:
+            
+            conn = self.db_pool.get_connection()
+            cursor = conn.cursor()
+            
+            # 使用事务 + FOR UPDATE锁定记录
+            cursor.execute("""
+                SELECT id, repo_url, source_url, pr_number, repo_name, pr_url, spec_content 
+                FROM pending_requests 
+                WHERE (status = 'pending' or status = 'failed')
+                LIMIT 8
+                FOR UPDATE;
+            """)
+            
+            requests = cursor.fetchall()
+            if not requests:
+                conn.commit()
+                return
+            # 更新状态为processing
+            update_ids = [str(r[0]) for r in requests]
+            cursor.execute(
+                "UPDATE pending_requests SET status = 'processing' "
+                f"WHERE id IN ({','.join(['%s'] * len(update_ids))})",
+                update_ids
+            )
+            conn.commit()
+            # 提交任务创建协程
+            tasks = []
+            for req in requests:
+                logger.info(f"{req[4]}提交任务创建协程")
+                request_data = {
+                    "repo_url": req[1],
+                    "source_url": req[2],
+                    "pr_number": req[3],
+                    "repo_name": req[4],
+                    "pr_url": req[5],
+                    "spec_content": req[6]
+                }
+                tasks.append(self.task_queue.put((req[0], request_data))) 
+            await asyncio.gather(*tasks)  # 最后统一等待所有任务完成
+  
+        except Exception as e:
+            conn.rollback()
+            logger.info(f"Database error: {e}")
+        finally:
+            cursor.close()
+            conn.close()
+    
+    async def process_request(self, request_id, request_data):
+        """
+        处理请求函数
+
+        本函数接收请求ID和请求数据作为参数，尝试执行业务逻辑并更新数据库中的请求状态
+
+        参数:
+        request_id (int): 请求的唯一标识符
+        request_data (dict): 包含请求详细信息的字典
+
+        返回:
+        无
+        """
+        try:
+            # 业务逻辑
+            taskStatus = await self.repair_handler(request_data)
+            logger.info(f"处理完毕 开始数据回库")
+            conn = self.db_pool.get_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE pending_requests SET status = %s WHERE id = %s",
+                (taskStatus, request_id)
+            )
+            conn.commit()
+            logger.info(f"处理完毕 数据回库成功")
+        except Exception as e:
+            logger.error(f"任务执行失败: {e}")
+            conn.rollback()
+            cursor.execute(
+                "UPDATE pending_requests SET status = 'failed' WHERE id = %s",
+                (request_id)
+            )
+            conn.commit()
+        finally:
+            cursor.close()
+            conn.close()
+
+    async def repair_handler(self, request_data) -> str:
+        """
+        处理修复请求的数据。
+
+        该函数从请求数据中提取必要的信息，组织成一个字典，并调用另一个函数来执行初始修复操作。
+
+        参数:
+        - request_data: 包含修复请求详细信息的字典，包括仓库URL、PR编号、规范内容等。
+
+        返回:
+        - 一个包含处理状态的字典，表示修复请求已被处理。
+        """
+        pr_data = {
+            "repo_url": request_data["repo_url"],
+            "source_url": request_data["source_url"],
+            "pr_number": request_data["pr_number"],
+            "repo_name": request_data["repo_name"],
+            "pr_url": request_data["pr_url"],
+        }
+        spec_content = request_data["spec_content"]
+        try:
+            await process_initial_repair(pr_data, spec_content)
+            return REPAIR_STATUS_COMPLETED
+        except Exception as e:
+            logger.error(f"任务执行失败: {e}")
+            return REPAIR_STATUS_FAILED

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-fastapi>=0.95.0
+fastapi==0.115.12
 gunicorn
-uvicorn[standard]>=0.22.0
+uvicorn[standard]==0.34.1
 python-dotenv>=1.0.0
 requests>=2.28.0
 pytest>=7.2.0
 pytest-asyncio>=0.20.3
 httpx~=0.28.1
 PyYAML~=6.0.2
+mysql-connector

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python3
+# ******************************************************************************
+# Copyright (c) openEuler. 2025. All rights reserved.
+# licensed under the Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#     http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN 'AS IS' BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR
+# PURPOSE.
+# See the Mulan PSL v2 for more details.
+# ******************************************************************************
+import unittest
+from unittest.mock import MagicMock, patch
+import asyncio
+from app.config import settings
+from app.utils.processor import RequestProcessor, REPAIR_STATUS_COMPLETED, REPAIR_STATUS_FAILED
+
+# 模拟配置
+settings.check_interval = 1  # 缩短检查间隔便于测试
+settings.thread_pool_size = 2
+
+class TestRequestProcessor(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        # 模拟数据库连接池
+        self.mock_db_pool = MagicMock()
+        self.mock_conn = MagicMock()
+        self.mock_cursor = MagicMock()
+        
+        # 设置模拟对象行为
+        self.mock_db_pool.get_connection.return_value = self.mock_conn
+        self.mock_conn.cursor.return_value = self.mock_cursor
+        
+        # 初始化被测对象
+        self.processor = RequestProcessor()
+        self.processor.db_pool = self.mock_db_pool
+        self.processor.task_queue = asyncio.Queue()
+
+    async def test_initialization(self):
+        """测试初始化是否正确创建线程池"""
+        # 验证线程池创建
+        self.assertEqual(len(asyncio.all_tasks()), settings.thread_pool_size)
+        
+        # 验证数据库连接池初始化
+        self.mock_db_pool.get_connection.assert_called_once()
+
+    async def test_process_pending_requests_normal_flow(self):
+        """测试正常处理挂起请求流程"""
+        # 模拟数据库返回2条pending请求
+        mock_requests = [
+            (1, 'repo1', 'source1', 123, 'repo_name1', 'pr_url1', 'spec1'),
+            (2, 'repo2', 'source2', 456, 'repo_name2', 'pr_url2', 'spec2')
+        ]
+        self.mock_cursor.fetchall.return_value = mock_requests
+        
+        # 执行测试方法
+        await self.processor.process_pending_requests()
+        
+        # 验证状态更新
+        self.mock_cursor.execute.assert_any_call(
+            "UPDATE pending_requests SET status = 'processing' WHERE id IN (%s,%s)",
+            ['1', '2']
+        )
+        
+        # 验证任务提交
+        self.assertEqual(self.processor.task_queue.qsize(), 2)
+
+    async def test_process_pending_requests_no_requests(self):
+        """测试无挂起请求时的处理"""
+        self.mock_cursor.fetchall.return_value = []
+        
+        await self.processor.process_pending_requests()
+        
+        # 验证没有执行更新操作
+        self.mock_cursor.execute.assert_not_called()
+
+    async def test_process_request_success(self):
+        """测试成功处理请求"""
+        # 模拟修复处理成功
+        with patch('your_module.process_initial_repair', return_value=None) as mock_repair:
+            await self.processor.process_request(1, {'spec_content': 'valid_spec'})
+            
+            # 验证状态更新
+            self.mock_cursor.execute.assert_any_call(
+                "UPDATE pending_requests SET status = 'completed' WHERE id = %s",
+                (1,)
+            )
+            mock_repair.assert_called_once()
+
+    async def test_process_request_failure(self):
+        """测试处理请求失败"""
+        # 模拟修复处理抛出异常
+        with patch('your_module.process_initial_repair', side_effect=Exception("Test error")):
+            await self.processor.process_request(1, {'spec_content': 'invalid_spec'})
+            
+            # 验证状态更新为failed
+            self.mock_cursor.execute.assert_any_call(
+                "UPDATE pending_requests SET status = 'failed' WHERE id = %s",
+                (1,)
+            )
+
+    async def test_repair_handler_success(self):
+        """测试修复处理器成功路径"""
+        with patch('your_module.process_initial_repair', return_value=None):
+            result = await self.processor.repair_handler({'spec_content': 'valid'})
+            self.assertEqual(result, REPAIR_STATUS_COMPLETED)
+
+    async def test_repair_handler_failure(self):
+        """测试修复处理器失败路径"""
+        with patch('your_module.process_initial_repair', side_effect=Exception("Test error")):
+            result = await self.processor.repair_handler({'spec_content': 'invalid'})
+            self.assertEqual(result, REPAIR_STATUS_FAILED)
+
+    async def test_concurrent_processing(self):
+        """测试并发处理能力"""
+        # 添加多个任务到队列
+        for i in range(5):
+            await self.processor.task_queue.put((i, {}))
+        
+        # 等待所有worker处理完成
+        await asyncio.sleep(0.1)  # 等待事件循环处理
+        
+        # 验证队列清空
+        self.assertEqual(self.processor.task_queue.qsize(), 0)
+        self.assertTrue(self.processor.task_queue.empty())
+
+    async def test_database_rollback_on_error(self):
+        """测试数据库事务回滚"""
+        # 强制触发数据库异常
+        self.mock_cursor.execute.side_effect = Exception("Database error")
+        
+        with self.assertLogs() as captured:
+            await self.processor.process_pending_requests()
+            
+            # 验证回滚和日志记录
+            self.assertIn("Database error", captured.output[0])
+            self.mock_conn.rollback.assert_called_once()
+
+    async def test_task_queue_error_handling(self):
+        """测试任务队列异常处理"""
+        # 创建会抛出异常的任务
+        async def failing_task():
+            raise ValueError("Task failed")
+        
+        # 提交异常任务
+        await self.processor.task_queue.put(failing_task())
+        
+        # 等待worker处理
+        await asyncio.sleep(0.1)
+        
+        # 验证任务完成（即使失败）
+        self.assertTrue(self.processor.task_queue.empty())


### PR DESCRIPTION
处理repair请求改用后台协程池并发处理，每个任务存入mysql后，定期执行，避免大批量请求oom问题引发的服务宕机和任务不执行等异常情况

Dockerfile 修改服务启动方式
app/api/endpoints/webhook.py 服务主入口不直接处理请求，先存入数据库
app/config.py 添加相关配置
app/main.py 延迟后启动后台协程池任务
app/utils/processor.py 协程池任务处理
tests/test_processor.py 测试类